### PR TITLE
fix: prevent exceptions when listing indices and constraints asynchronously

### DIFF
--- a/NFalkorDB.Tests/FalkorDBAPITest.cs
+++ b/NFalkorDB.Tests/FalkorDBAPITest.cs
@@ -1264,4 +1264,89 @@ public class FalkorDBAPITest : BaseTest
         var afterReset = _api.Slowlog();
         Assert.NotNull(afterReset);
     }
+
+    [Theory]
+    [InlineData(new string[0], "CALL dbms.functions()")]
+    [InlineData(new[] { "name" }, "CALL dbms.functions() YIELD name")]
+    [InlineData(new[] { "name", "internal" }, "CALL dbms.functions() YIELD name,internal")]
+    public void BuildQueryBodyForProcedureCall(string[] fields, string expected)
+    {
+        var kwargs = new Dictionary<string, List<string>>
+        {
+            { "y", fields.ToList() }
+        };
+        var args = Enumerable.Empty<string>();
+
+        var body = Graph.BuildQueryBodyForProcedureCall("dbms.functions", ref args, kwargs);
+
+        Assert.Equal(expected, body);
+    }
+
+    [Fact]
+    public void TestCallProcedureWithYield()
+    {
+        _api.Query("CREATE (:Person {name:'roi'})");
+
+        var kwargs = new Dictionary<string, List<string>>
+        {
+            { "y", new List<string> { "name", "internal" } }
+        };
+
+        var result = _api.CallProcedure("dbms.functions", null, kwargs);
+
+        Assert.Equal(2, result.First().Values.Count);
+        Assert.IsType<string>(result.First().Values[0]);
+        Assert.IsType<bool>(result.First().Values[1]);
+    }
+
+    [Fact]
+    public void TestCallProcedureReadOnlyWithYield()
+    {
+        _api.Query("CREATE (:Person {name:'roi'})");
+
+        var kwargs = new Dictionary<string, List<string>>
+        {
+            { "y", new List<string> { "name", "internal" } }
+        };
+
+        var result = _api.CallProcedureReadOnly("dbms.functions", null, kwargs);
+
+        Assert.Equal(2, result.First().Values.Count);
+        Assert.IsType<string>(result.First().Values[0]);
+        Assert.IsType<bool>(result.First().Values[1]);
+    }
+
+    [Fact]
+    public async Task TestCallProcedureAsyncWithYield()
+    {
+        _api.Query("CREATE (:Person {name:'roi'})");
+
+        var kwargs = new Dictionary<string, List<string>>
+        {
+            { "y", new List<string> { "name", "internal" } }
+        };
+
+        var result = await _api.CallProcedureAsync("dbms.functions", null, kwargs);
+
+        Assert.Equal(2, result.First().Values.Count);
+        Assert.IsType<string>(result.First().Values[0]);
+        Assert.IsType<bool>(result.First().Values[1]);
+    }
+
+    [Fact]
+    public async Task TestCallProcedureReadOnlyAsyncWithYield()
+    {
+        _api.Query("CREATE (:Person {name:'roi'})");
+
+        var kwargs = new Dictionary<string, List<string>>
+        {
+            { "y", new List<string> { "name", "internal" } }
+        };
+
+        var result = await _api.CallProcedureReadOnlyAsync("dbms.functions", null, kwargs);
+
+        Assert.Equal(2, result.First().Values.Count);
+        Assert.IsType<string>(result.First().Values[0]);
+        Assert.IsType<bool>(result.First().Values[1]);
+    }
 }

--- a/NFalkorDB.Tests/FalkorDBAPITest.cs
+++ b/NFalkorDB.Tests/FalkorDBAPITest.cs
@@ -419,6 +419,7 @@ public class FalkorDBAPITest : BaseTest
     [Fact]
     public async Task TestIndexHelpersListIndicesAsync()
     {
+        _api.Query("CREATE (:seed)");
         var indicesResult = await _api.ListIndicesAsync();
         // Shape is server-dependent; just ensure the call succeeds and returns a header
         Assert.NotNull(indicesResult);
@@ -427,6 +428,7 @@ public class FalkorDBAPITest : BaseTest
     [Fact]
     public async Task TestIndexHelpersListConstraintsAsync()
     {
+        _api.Query("CREATE (:seed)");
         var constraints = await _api.ListConstraintsAsync();
         // Shape is server-dependent; just ensure the call succeeds and returns a header
         Assert.NotNull(constraints);

--- a/NFalkorDB.Tests/FalkorDBAPITest.cs
+++ b/NFalkorDB.Tests/FalkorDBAPITest.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Xunit;
 using static NFalkorDB.Statistics;
 
@@ -413,6 +414,22 @@ public class FalkorDBAPITest : BaseTest
         var indicesResult = _api.ListIndices();
         // Shape is server-dependent; just ensure the call succeeds and returns a header
         Assert.NotNull(indicesResult);
+    }
+
+    [Fact]
+    public async Task TestIndexHelpersListIndicesAsync()
+    {
+        var indicesResult = await _api.ListIndicesAsync();
+        // Shape is server-dependent; just ensure the call succeeds and returns a header
+        Assert.NotNull(indicesResult);
+    }
+
+    [Fact]
+    public async Task TestIndexHelpersListConstraintsAsync()
+    {
+        var constraints = await _api.ListConstraintsAsync();
+        // Shape is server-dependent; just ensure the call succeeds and returns a header
+        Assert.NotNull(constraints);
     }
 
     [Fact]

--- a/NFalkorDB/Graph.cs
+++ b/NFalkorDB/Graph.cs
@@ -291,7 +291,7 @@ public class Graph
 
         queryBody.Append(args != null ? $"CALL {procedure}({string.Join(",", args)})" : $"CALL {procedure}()");
 
-        if (kwargs != null && kwargs.TryGetValue("y", out var kwargsList) && kwargsList.Count > 0)
+        if (kwargs != null && kwargs.TryGetValue("y", out var kwargsList) && kwargsList != null && kwargsList.Count > 0)
         {
             queryBody.Append($" YIELD {string.Join(",", kwargsList)}");
         }

--- a/NFalkorDB/Graph.cs
+++ b/NFalkorDB/Graph.cs
@@ -283,7 +283,7 @@ public class Graph
         return ReadOnlyQueryAsync(queryBody, flags: flags);
     }
 
-    private static string BuildQueryBodyForProcedureCall(string procedure, ref IEnumerable<string> args, Dictionary<string, List<string>> kwargs)
+    internal static string BuildQueryBodyForProcedureCall(string procedure, ref IEnumerable<string> args, Dictionary<string, List<string>> kwargs)
     {
         args = args?.Select(QuoteString);
 
@@ -291,9 +291,9 @@ public class Graph
 
         queryBody.Append(args != null ? $"CALL {procedure}({string.Join(",", args)})" : $"CALL {procedure}()");
 
-        if (kwargs != null && kwargs.TryGetValue("y", out var kwargsList))
+        if (kwargs != null && kwargs.TryGetValue("y", out var kwargsList) && kwargsList.Count > 0)
         {
-            queryBody.Append(string.Join(",", kwargsList));
+            queryBody.Append($" YIELD {string.Join(",", kwargsList)}");
         }
 
         return queryBody.ToString();

--- a/NFalkorDB/Graph.cs
+++ b/NFalkorDB/Graph.cs
@@ -233,18 +233,9 @@ public class Graph
     /// <returns>A result set.</returns>
     public ResultSet CallProcedure(string procedure, IEnumerable<string> args = null, Dictionary<string, List<string>> kwargs = null, CommandFlags flags = CommandFlags.None)
     {
-        args = args?.Select(a => QuoteString(a));
+        var queryBody = BuildQueryBodyForProcedureCall(procedure, ref args, kwargs);
 
-        var queryBody = new StringBuilder();
-
-        queryBody.Append(args != null ? $"CALL {procedure}({string.Join(",", args)})" : $"CALL {procedure}()");
-
-        if (kwargs != null && kwargs.TryGetValue("y", out var kwargsList))
-        {
-            queryBody.Append(string.Join(",", kwargsList));
-        }
-
-        return Query(queryBody.ToString(), flags: flags);
+        return Query(queryBody, flags: flags);
     }
 
     /// <summary>
@@ -255,20 +246,11 @@ public class Graph
     /// <param name="kwargs">A collection of keyword arguments.</param>
     /// <param name="flags">[Optional] Command flags that are to be sent to the StackExchange.Redis connection multiplexer...</param>/// 
     /// <returns>A result set.</returns>
-    public Task<ResultSet> CallProcedureAsync(string procedure, IEnumerable<string> args, Dictionary<string, List<string>> kwargs, CommandFlags flags = CommandFlags.None)
+    public Task<ResultSet> CallProcedureAsync(string procedure, IEnumerable<string> args = null, Dictionary<string, List<string>> kwargs = null, CommandFlags flags = CommandFlags.None)
     {
-        args = args.Select(a => QuoteString(a));
+        var queryBody = BuildQueryBodyForProcedureCall(procedure, ref args, kwargs);
 
-        var queryBody = new StringBuilder();
-
-        queryBody.Append($"CALL {procedure}({string.Join(",", args)})");
-
-        if (kwargs.TryGetValue("y", out var kwargsList))
-        {
-            queryBody.Append(string.Join(",", kwargsList));
-        }
-
-        return QueryAsync(queryBody.ToString(), flags: flags);
+        return QueryAsync(queryBody, flags: flags);
     }
 
     /// <summary>
@@ -281,18 +263,9 @@ public class Graph
     /// <returns>A result set.</returns>
     public ResultSet CallProcedureReadOnly(string procedure, IEnumerable<string> args = null, Dictionary<string, List<string>> kwargs = null, CommandFlags flags = CommandFlags.None)
     {
-        args = args.Select(a => QuoteString(a));
+        var queryBody = BuildQueryBodyForProcedureCall(procedure, ref args, kwargs);
 
-        var queryBody = new StringBuilder();
-
-        queryBody.Append($"CALL {procedure}({string.Join(",", args)})");
-
-        if (kwargs != null && kwargs.TryGetValue("y", out var kwargsList))
-        {
-            queryBody.Append(string.Join(",", kwargsList));
-        }
-
-        return ReadOnlyQuery(queryBody.ToString(), flags: flags);
+        return ReadOnlyQuery(queryBody, flags: flags);
     }
 
     /// <summary>
@@ -305,18 +278,25 @@ public class Graph
     /// <returns>A result set.</returns>
     public Task<ResultSet> CallProcedureReadOnlyAsync(string procedure, IEnumerable<string> args = null, Dictionary<string, List<string>> kwargs = null, CommandFlags flags = CommandFlags.None)
     {
-        args = args.Select(a => QuoteString(a));
+        var queryBody = BuildQueryBodyForProcedureCall(procedure, ref args, kwargs);
+
+        return ReadOnlyQueryAsync(queryBody, flags: flags);
+    }
+
+    private static string BuildQueryBodyForProcedureCall(string procedure, ref IEnumerable<string> args, Dictionary<string, List<string>> kwargs)
+    {
+        args = args?.Select(QuoteString);
 
         var queryBody = new StringBuilder();
 
-        queryBody.Append($"CALL {procedure}({string.Join(",", args)})");
+        queryBody.Append(args != null ? $"CALL {procedure}({string.Join(",", args)})" : $"CALL {procedure}()");
 
-        if (kwargs.TryGetValue("y", out var kwargsList))
+        if (kwargs != null && kwargs.TryGetValue("y", out var kwargsList))
         {
             queryBody.Append(string.Join(",", kwargsList));
         }
 
-        return ReadOnlyQueryAsync(queryBody.ToString(), flags: flags);
+        return queryBody.ToString();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

This PR fixes the `ListIndicesAsync` and `ListConstraintsAsync` methods so that calls no longer throw exceptions when invoked. The async and read-only procedure call paths now handle optional inputs consistently with sync behavior.

## What Changed

- Consolidated CALL query construction into a shared `BuildQueryBodyForProcedureCall` helper
- Reused the shared `BuildQueryBodyForProcedureCall` logic across sync, async, and read-only procedure calls
- Updated the `CallProcedureAsync` method signature to accept optional `args` and `kwargs` matching the `CallProcedure` method
- Added consistent null-safe handling for `args` quoting and `kwargs` processing
- Added async API tests for index and constraint listing success paths

## Testing

Added tests:
- TestIndexHelpersListIndicesAsync
- TestIndexHelpersListConstraintsAsync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Procedure calls now accept optional positional and keyword arguments and consistently expose yield fields across sync, async and read-only variants.

* **Tests**
  * Added async tests for listing indexes and constraints.
  * Added comprehensive tests covering procedure-call behavior across sync/async, read-only, and yield-field scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->