### PR TITLE
fix(docs): update Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![FalkorDB Official  NET support-04-25](https://github.com/user-attachments/assets/659113e1-7e5b-433a-8a1d-199324278e22)
-[![Discord](https://img.shields.io/discord/1146782921294884966?style=flat-square)](https://discord.gg/ErBEqN9E)
+[![Discord](https://img.shields.io/discord/1146782921294884966?style=flat-square)](https://discord.gg/6M4QwDXn2w)
 [![license](https://img.shields.io/github/license/FalkorDB/NFalkorDB.svg)](https://github.com/FalkorDB/NFalkorDB/blob/master/LICENSE)
 [![Release](https://img.shields.io/github/release/FalkorDB/NFalkorDB.svg)](https://github.com/FalkorDB/NFalkorDB/releases/latest)
 [![Build Status](https://github.com/falkordb/NFalkorDB/actions/workflows/dotnet.yml/badge.svg)](https://github.com/falkordb/NFalkorDB/actions/workflows/dotnet.yml)


### PR DESCRIPTION
## Summary
Replace the deprecated Discord invite link with the new one across all documentation files.

## Changes
- **Old link:** `https://discord.gg/ErBEqN9E`
- **New link:** `https://discord.gg/6M4QwDXn2w`

## Testing
N/A — documentation-only change.

## Memory / Performance Impact
N/A

## Related Issues
N/A