### PR TITLE
Fix: disable default 5000ms operation timeout that kills long-running queries

### DIFF
--- a/NFalkorDB/FalkorDB.cs
+++ b/NFalkorDB/FalkorDB.cs
@@ -32,7 +32,7 @@ public sealed class FalkorDB
     /// <param name="db">Existing StackExchange.Redis database instance to use.</param>
     public FalkorDB(IDatabase db = null)
     {
-        _db = db ?? ConnectionMultiplexer.Connect("localhost").GetDatabase();
+        _db = db ?? ConnectionMultiplexer.Connect(BuildConfiguration("localhost")).GetDatabase();
     }
 
     /// <summary>

--- a/NFalkorDB/FalkorDB.cs
+++ b/NFalkorDB/FalkorDB.cs
@@ -12,6 +12,18 @@ namespace NFalkorDB;
 /// </summary>
 public sealed class FalkorDB
 {
+    /// <summary>
+    /// Sync/async operation timeout applied when the configuration does not specify one:
+    /// effectively no client-side deadline. Graph queries routinely exceed
+    /// StackExchange.Redis' default 5000ms timeout (bulk loads, deep traversals), which
+    /// would otherwise fail the call with a <see cref="RedisTimeoutException"/> while the
+    /// server keeps executing the query - so retrying could duplicate writes. Query
+    /// duration is governed by the server's TIMEOUT / TIMEOUT_DEFAULT configuration
+    /// instead, matching the other FalkorDB clients. To use a different timeout, pass
+    /// <c>syncTimeout=...</c> / <c>asyncTimeout=...</c> in the configuration string.
+    /// </summary>
+    private const int DefaultOperationTimeoutMilliseconds = int.MaxValue;
+
     private readonly IDatabase _db;
 
     /// <summary>
@@ -34,8 +46,29 @@ public sealed class FalkorDB
             throw new ArgumentException("Configuration must be provided.", nameof(configuration));
         }
 
-        var mux = ConnectionMultiplexer.Connect(configuration);
+        var mux = ConnectionMultiplexer.Connect(BuildConfiguration(configuration));
         _db = mux.GetDatabase();
+    }
+
+    /// <summary>
+    /// Parses the configuration and removes the client-side operation timeout unless the
+    /// caller set one explicitly (see <see cref="DefaultOperationTimeoutMilliseconds"/>).
+    /// </summary>
+    private static ConfigurationOptions BuildConfiguration(string configuration)
+    {
+        var options = ConfigurationOptions.Parse(configuration);
+
+        if (configuration.IndexOf("syncTimeout=", StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            options.SyncTimeout = DefaultOperationTimeoutMilliseconds;
+        }
+
+        if (configuration.IndexOf("asyncTimeout=", StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            options.AsyncTimeout = DefaultOperationTimeoutMilliseconds;
+        }
+
+        return options;
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

`FalkorDB` connected through StackExchange.Redis with its default **5000ms sync/async operation timeout**. Any graph query taking longer than 5 seconds (bulk loads, deep traversals) fails with:

```
RedisTimeoutException: Timeout performing GRAPH.QUERY (5000ms), ...
```

Meanwhile the server keeps executing the query, so retrying a write can duplicate data.

Same class of bug already fixed in falkordb-rs (FalkorDB/falkordb-rs#297, redis-rs 500ms default), JFalkorDB (FalkorDB/JFalkorDB#282, Jedis 2000ms default) and falkordb-go (FalkorDB/falkordb-go#101, go-redis 3s default). falkordb-py, falkordb-ts and falkordb-php are unaffected.

## Fix

Both constructors now parse the configuration and set `SyncTimeout`/`AsyncTimeout` to `int.MaxValue` (effectively no client-side deadline) **unless the caller specified them explicitly** in the configuration string. Query duration is governed by the server's `TIMEOUT` / `TIMEOUT_DEFAULT` configuration, consistent with the other FalkorDB clients. Users passing an existing `IDatabase` are untouched.

## Validation

Against FalkorDB v4.20.1, `UNWIND range(1,200000000) AS x RETURN sum(x)` (~13s):

| | result |
|---|---|
| before | **fails at 5010ms** with RedisTimeoutException |
| after | **succeeds in 13.4s** |
| explicit `syncTimeout=2000` | still fails at 2012ms as expected (opt-in preserved) |