### PR TITLE
fix(client): stop sending CommandFlags as a GRAPH.LIST argument

### DIFF
--- a/NFalkorDB.Tests/FalkorDBAPITest.cs
+++ b/NFalkorDB.Tests/FalkorDBAPITest.cs
@@ -30,13 +30,16 @@ public class FalkorDBAPITest : BaseTest
         graph.Query("RETURN 1");
 
         var graphs = client.ListGraphs();
-        // Depending on server/module version, GRAPH.LIST contents may vary; just ensure the call succeeds.
         Assert.NotNull(graphs);
+        Assert.Contains("phase1_list_graphs", graphs);
 
-        // round-trip a config value (where allowed)
-        // for safety, just GET a common configuration key
-        var timeoutConfig = client.GetConfig("TIMEOUT_MS");
-        // value may be null or numeric depending on server config, but call should not throw
+        // round-trip a real configuration field
+        var timeoutConfig = client.GetConfig("TIMEOUT_DEFAULT");
+        Assert.NotNull(timeoutConfig);
+
+        // an unknown field is reported by the server as an error, which the
+        // client swallows and reports as "no value"
+        Assert.Null(client.GetConfig("NOT_A_REAL_CONFIG_FIELD"));
     }
 
     [Fact]

--- a/NFalkorDB/FalkorDB.cs
+++ b/NFalkorDB/FalkorDB.cs
@@ -68,7 +68,7 @@ public sealed class FalkorDB
     {
         try
         {
-            var result = _db.Execute(Command.LIST, flags);
+            var result = _db.Execute(Command.LIST, Array.Empty<object>(), flags);
 
             if (result.Resp2Type != ResultType.Array)
             {
@@ -96,7 +96,7 @@ public sealed class FalkorDB
     /// </summary>
     public async System.Threading.Tasks.Task<IReadOnlyList<string>> ListGraphsAsync(CommandFlags flags = CommandFlags.None)
     {
-        var result = await _db.ExecuteAsync(Command.LIST, flags).ConfigureAwait(false);
+        var result = await _db.ExecuteAsync(Command.LIST, Array.Empty<object>(), flags).ConfigureAwait(false);
 
         if (result.Resp2Type != ResultType.Array)
         {


### PR DESCRIPTION
## Summary
Fixes #84, which has kept `build` red on `master` and blocked every open PR in this repo (including the CI standardization PR #83 and five Dependabot PRs).

`ListGraphs`/`ListGraphsAsync` called:

```csharp
_db.Execute(Command.LIST, flags);
```

That binds to `Execute(string command, params object[] args)`, so the `CommandFlags` value was serialized as a command **argument** — the client literally sent `GRAPH.LIST None`.

Two consequences:

1. The server answers `ERR wrong number of arguments for 'graph.LIST' command`, which the `catch (RedisServerException)` block swallowed. **`ListGraphs()` always returned an empty list.**
2. That unexpected error reply desynchronizes StackExchange.Redis's request/response matching on the connection. The next command that returns an error never has its reply matched and times out — which is exactly how `CanConstructFromConfigurationStringAndListGraphsAndConfig` failed:

```
StackExchange.Redis.RedisTimeoutException : Timeout performing GRAPH.CONFIG (5000ms),
next: GRAPH.LIST, qs: 3, sync-ops: 3 ...
```

I confirmed with a raw socket that the server replies correctly to all four commands in that sequence, so this is purely client-side.

## Changes
- `FalkorDB.ListGraphs` / `ListGraphsAsync`: pass `Array.Empty<object>()` so `flags` binds to the `CommandFlags` overload.
- `CanConstructFromConfigurationStringAndListGraphsAndConfig`:
  - assert `ListGraphs()` actually contains the graph it just created (this would have caught the bug),
  - query `TIMEOUT_DEFAULT` — `TIMEOUT_MS` is not a FalkorDB configuration field at all,
  - assert the unknown-field path returns `null` rather than throwing.

## Testing
Reproduced and verified locally against `falkordb/falkordb:latest` with .NET 10.

Before — bisected with a standalone probe:
```
E: query,list,config(invalid): RedisTimeoutException   (list count=0)
```
After:
```
E: query,list,config(invalid): OK                      (list count=8)
```

Full suite:
```
Passed! - Failed: 0, Passed: 85, Skipped: 2, Total: 87
```

## Memory / Performance Impact
N/A — no allocation or lifecycle change; one fewer malformed command per `ListGraphs` call.

## Related Issues
Fixes #84. Unblocks #83, #75, #78, #79, #80, #81.