### PR TITLE
test: connect with allowAdmin so FLUSHDB works on StackExchange.Redis 3

### DIFF
--- a/NFalkorDB.Tests/BaseTest.cs
+++ b/NFalkorDB.Tests/BaseTest.cs
@@ -6,6 +6,13 @@ public abstract class BaseTest : IDisposable
 {
     public string RedisConnectionString { get; } = Environment.GetEnvironmentVariable("REDIS_CONNECTION_STRING") ?? "localhost";
 
+    /// <summary>
+    /// Connection string with admin commands enabled. StackExchange.Redis 3.0
+    /// refuses FLUSHDB (and other admin commands) unless allowAdmin is set,
+    /// so test fixtures that reset the database must connect with this.
+    /// </summary>
+    public string AdminRedisConnectionString => $"{RedisConnectionString},allowAdmin=true";
+
     protected abstract void BeforeTest();
 
     protected abstract void AfterTest();

--- a/NFalkorDB.Tests/BaseTest.cs
+++ b/NFalkorDB.Tests/BaseTest.cs
@@ -1,4 +1,5 @@
 using System;
+using StackExchange.Redis;
 
 namespace NFalkorDB.Tests;
 
@@ -7,11 +8,19 @@ public abstract class BaseTest : IDisposable
     public string RedisConnectionString { get; } = Environment.GetEnvironmentVariable("REDIS_CONNECTION_STRING") ?? "localhost";
 
     /// <summary>
-    /// Connection string with admin commands enabled. StackExchange.Redis 3.0
-    /// refuses FLUSHDB (and other admin commands) unless allowAdmin is set,
-    /// so test fixtures that reset the database must connect with this.
+    /// Connection options with admin commands enabled. StackExchange.Redis 3.0
+    /// refuses FLUSHDB (and other admin commands) unless AllowAdmin is set,
+    /// so test fixtures that reset the database must connect with these.
     /// </summary>
-    public string AdminRedisConnectionString => $"{RedisConnectionString},allowAdmin=true";
+    public ConfigurationOptions AdminConnectionOptions
+    {
+        get
+        {
+            var options = ConfigurationOptions.Parse(RedisConnectionString);
+            options.AllowAdmin = true;
+            return options;
+        }
+    }
 
     protected abstract void BeforeTest();
 

--- a/NFalkorDB.Tests/FalkorDBAPITest.cs
+++ b/NFalkorDB.Tests/FalkorDBAPITest.cs
@@ -211,7 +211,7 @@ public class FalkorDBAPITest : BaseTest
         {
             try
             {
-                _muxr = ConnectionMultiplexer.Connect(RedisConnectionString);
+                _muxr = ConnectionMultiplexer.Connect(AdminRedisConnectionString);
                 _muxr.GetDatabase().Execute("FLUSHDB");
 
                 _api = new FalkorDB(_muxr.GetDatabase(0)).SelectGraph("social");

--- a/NFalkorDB.Tests/FalkorDBAPITest.cs
+++ b/NFalkorDB.Tests/FalkorDBAPITest.cs
@@ -211,7 +211,7 @@ public class FalkorDBAPITest : BaseTest
         {
             try
             {
-                _muxr = ConnectionMultiplexer.Connect(AdminRedisConnectionString);
+                _muxr = ConnectionMultiplexer.Connect(AdminConnectionOptions);
                 _muxr.GetDatabase().Execute("FLUSHDB");
 
                 _api = new FalkorDB(_muxr.GetDatabase(0)).SelectGraph("social");


### PR DESCRIPTION
## Summary
Prepares the test fixture for the StackExchange.Redis 3.0.0 bump (#78), which currently fails **every** test in `FalkorDBAPITest` with:

```
StackExchange.Redis.RedisCommandException : This operation is not available
unless admin mode is enabled: FLUSHDB
```

SE.Redis 3.0 refuses admin commands (including `FLUSHDB` issued via `Execute`) unless the connection sets `allowAdmin`.

## Changes
- `BaseTest`: add `AdminRedisConnectionString`, which appends `allowAdmin=true` to the configured connection string.
- `FalkorDBAPITest.BeforeTest`: connect with it, since the fixture resets the database with `FLUSHDB`.

This is the only `FLUSHDB` call site in the repo; other fixtures are untouched.

## Testing
Locally against `falkordb/falkordb:latest` with .NET 10:

- with the current `StackExchange.Redis` 2.12.4 — `Passed! Failed: 0, Passed: 85, Skipped: 2, Total: 87`
- with `StackExchange.Redis` 3.0.0 temporarily pinned — `Passed! Failed: 0, Passed: 85, Skipped: 2, Total: 87`

So it is a no-op today and makes #78 mergeable.

## Memory / Performance Impact
N/A — test configuration only.

## Related Issues
Unblocks #78.