### PR TITLE
chore(release): 1.1.0

### DIFF
--- a/NFalkorDB/NFalkorDB.csproj
+++ b/NFalkorDB/NFalkorDB.csproj
@@ -5,15 +5,15 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Tom Hanks (tombatron), John Weber (jweber), Jason Geyen (jgeyen), Rolf Wessels (rolfwessels), Rob Povey (polygonhell)</Authors>
     <Company />
-    <AssemblyVersion>1.0.6.0</AssemblyVersion>
-    <FileVersion>1.0.6.0</FileVersion>
-    <Version>1.0.6</Version>
-    <Description>A series of extension methods for use with StackExchange.Redis 2.x and the FalkorDB Redis module.</Description>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.1.0</Version>
+    <Description>A series of extension methods for use with StackExchange.Redis 3.x and the FalkorDB Redis module.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/falkordb/NFalkorDB</RepositoryUrl>
     <ProjectRepository>https://github.com/falkordb/NFalkorDB</ProjectRepository>
     <LangVersion>latest</LangVersion>
-    <PackageVersion>1.0.6</PackageVersion>
+    <PackageVersion>1.1.0</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -29,6 +29,7 @@
     <PackageLicenseFile>license.txt</PackageLicenseFile>
     <PackageReleaseNotes>    1.0.0 - Initial version.
                              1.0.1 - Added default constructor.
+                             1.1.0 - Target StackExchange.Redis 3.x; fix ListGraphs, which sent CommandFlags as a command argument and always returned an empty list.
     </PackageReleaseNotes>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
Prepares the 1.1.0 release. Minor rather than patch because the package now targets **StackExchange.Redis 3.x** (a major dependency upgrade) and `ListGraphs` changes observable behaviour — it previously always returned an empty list.

## Changes
- `Version`, `PackageVersion`, `AssemblyVersion`, `FileVersion` → `1.1.0`.
- Package `Description` updated: it still advertised "StackExchange.Redis 2.x" after the 3.0.0 bump.
- `PackageReleaseNotes` entry for 1.1.0.

## Notable changes since v1.0.6
- `fix(client)`: stop sending `CommandFlags` as a `GRAPH.LIST` argument (#85, fixes #84) — `ListGraphs()` now actually returns the graphs.
- `test`: connect with admin mode so `FLUSHDB` works on StackExchange.Redis 3 (#86).
- `ci(dotnet)`: test against `falkordb/falkordb:latest`, with a daily `edge` canary (#83).
- Dependency bumps: StackExchange.Redis 2.12.4 → 3.0.0 (#78), plus action and test-tooling updates (#75, #79, #80, #81).
- `fix(docs)`: update Discord invite link (#73).

## Testing
Locally against `falkordb/falkordb:latest` on .NET 10:
```
dotnet test --configuration Release
Passed! - Failed: 0, Passed: 85, Skipped: 2, Total: 87
```
`dotnet build --configuration Release` produces `NFalkorDB.1.1.0.nupkg` with 0 errors.

## Memory / Performance Impact
N/A — packaging metadata only.

## Related Issues
Follow-up to #85, #86.