### PR TITLE
ci(publish): use NuGet Trusted Publishing instead of a long-lived API key

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ jobs:
 
     runs-on: ubuntu-24.04
 
+    permissions:
+      contents: read
+      id-token: write # required to request the OIDC token for NuGet Trusted Publishing
+
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
     - name: Setup .NET
@@ -21,7 +25,10 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore --configuration Release                
+    - name: NuGet login (OIDC -> short-lived API key)
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+      id: login
+      with:
+        user: ${{ vars.NUGET_USER || 'FalkorDB' }}
     - name: Publish NuGet Package
-      env:
-        api_key: ${{secrets.NUGET_API_KEY}}
-      run: "dotnet nuget push NFalkorDB/bin/Release/*.nupkg --skip-duplicate --source https://api.nuget.org/v3/index.json --api-key $api_key"
+      run: "dotnet nuget push NFalkorDB/bin/Release/*.nupkg --skip-duplicate --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }}"


### PR DESCRIPTION
## Summary
The `NUGET_API_KEY` secret (created 2025-03-27) has expired — the v1.1.0 publish run failed with `403 (The specified API key is invalid, has expired, or does not have permission to publish...)`. nuget.org Trusted Publishing is now configured for this repo, so the workflow should exchange a GitHub OIDC token for a short-lived (1 hour) API key instead of relying on a long-lived secret.

## Changes
- `publish.yml`: add job-level `permissions:` with `id-token: write` (required to mint the OIDC token) and `contents: read`.
- Add a SHA-pinned `NuGet/login@v1.2.0` step (`id: login`) that performs the OIDC token exchange.
- `dotnet nuget push` now uses `--api-key ${{ steps.login.outputs.NUGET_API_KEY }}`; the `env: api_key: ${{ secrets.NUGET_API_KEY }}` block is removed.
- The nuget.org username defaults to the package owner `FalkorDB` and can be overridden with a repo/org Actions **variable** `NUGET_USER` if the trust policy is owned by a different profile.

Note: the workflow file name stays `publish.yml`, because the nuget.org trust policy binds to owner + repo + workflow file name.

## Testing
- YAML parses cleanly; the `build` required check runs the full test suite.
- End-to-end verification is the `workflow_dispatch` run against `master` publishing 1.1.0 to nuget.org (done right after merge).

## Memory / Performance Impact
N/A — CI only.

## Related Issues
Follow-up to the v1.1.0 release (`f597269`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing authentication for improved security.
  * Publishing now uses configurable identity-based credentials instead of a stored API key.
  * Adjusted workflow permissions to support secure package releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->